### PR TITLE
fix: 프로필 이미지 제거 기능 구현

### DIFF
--- a/docs/be/API.md
+++ b/docs/be/API.md
@@ -185,6 +185,13 @@ async function refreshAccessToken() {
 **Request Parts:**
 - `nickname` (String, 선택) - 닉네임 (10자 이내)
 - `profileImage` (File, 선택) - 프로필 이미지 (JPG/PNG/GIF, 최대 5MB)
+- `removeImage` (Boolean, 선택) - 이미지 제거 플래그
+
+**이미지 처리:**
+- `profileImage: [File]` - 새 이미지로 교체 (기존 이미지는 고아 처리 → TTL 1시간 복원)
+- `removeImage: true` - 기존 이미지 제거 (TTL 1시간 후 배치 삭제)
+- 둘 다 없음 - 이미지 유지
+- **주의:** removeImage와 profileImage 동시 전달 시 **profileImage가 우선 적용**됨
 
 **응답:**
 - 200: `update_profile_success` → 수정된 정보 반환

--- a/src/main/java/com/ktb/community/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/ktb/community/dto/request/UpdateProfileRequest.java
@@ -21,6 +21,15 @@ public class UpdateProfileRequest {
     
     @Size(max = 10, message = "닉네임은 최대 10자입니다")
     private String nickname;
-    
+
     private MultipartFile profileImage;
+
+    /**
+     * 선택: 프로필 이미지 제거 플래그
+     * - true: 기존 이미지 제거 (TTL 복원 + 관계 해제)
+     * - false/null: 기존 이미지 유지
+     *
+     * 주의: removeImage와 profileImage 동시 전달 시 profileImage가 우선 적용됨
+     */
+    private Boolean removeImage;
 }

--- a/src/main/java/com/ktb/community/service/UserService.java
+++ b/src/main/java/com/ktb/community/service/UserService.java
@@ -73,7 +73,9 @@ public class UserService {
             user.updateNickname(request.getNickname());
         }
         
-        // 프로필 이미지 업로드 및 변경 (있을 경우)
+        // ========== 프로필 이미지 처리 ==========
+
+        // Case 1: 새 이미지로 교체 (profileImage: File) - 최우선
         if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
             // 1. 기존 이미지 TTL 복원 (고아 이미지 처리)
             Image oldImage = user.getProfileImage();
@@ -94,6 +96,21 @@ public class UserService {
 
             log.info("[User] 프로필 이미지 변경: imageId={}", newImage.getImageId());
         }
+        // Case 2: 이미지 제거 요청 (removeImage: true)
+        else if (Boolean.TRUE.equals(request.getRemoveImage())) {
+            Image oldImage = user.getProfileImage();
+            if (oldImage != null) {
+                // TTL 복원 (고아 이미지 처리)
+                oldImage.setExpiresAt(LocalDateTime.now().plusHours(1));
+                log.info("[User] 고아 이미지 TTL 복원: imageId={}, expiresAt={}",
+                         oldImage.getImageId(), oldImage.getExpiresAt());
+
+                // 관계 해제
+                user.updateProfileImage(null);
+                log.info("[User] 프로필 이미지 제거: userId={}", userId);
+            }
+        }
+        // Case 3: 이미지 유지 (둘 다 없음)
 
         return UserResponse.from(user);
     }


### PR DESCRIPTION
## 문제점

프로필 이미지 변경은 구현되었으나 **제거 기능이 누락**되어 있습니다.
게시글 API는 제거/변경/유지 3가지 케이스를 지원하지만, 프로필 API는 변경만 가능합니다.

## 해결 방안

### 1. DTO 수정
`UpdateProfileRequest`에 `removeImage` 필드 추가
- Boolean 타입 (true: 제거, false/null: 유지)

### 2. Service 로직 수정
`UserService.updateProfile()`에 3가지 케이스 분기 구현
- **Case 1**: `profileImage` 있음 → 이미지 변경 (최우선)
- **Case 2**: `removeImage=true` → 이미지 제거
- **Case 3**: 둘 다 없음 → 이미지 유지

### 3. 우선순위 규칙
`removeImage=true`와 `profileImage` 동시 전달 시 → **`profileImage`가 우선 적용**

### 4. 고아 이미지 처리
제거 또는 변경 시 기존 이미지 TTL 1시간 복원 → 배치 작업이 자동 삭제

## 변경 파일
- `dto/request/UpdateProfileRequest.java` - removeImage 필드 추가
- `service/UserService.java` - 3가지 케이스 분기 로직
- `test/.../UserServiceTest.java` - 단위 테스트 4개 추가
- `docs/be/API.md` - Section 2.3 업데이트

## 테스트 결과
```
./gradlew test --tests UserServiceTest
✅ 14 tests completed, 0 failed (100% success)
```

### 테스트 케이스
1. `updateProfile_RemoveImage_Success` - 정상 제거
2. `updateProfile_RemoveImage_WithNewImage_Priority` - 우선순위 검증
3. `updateProfile_RemoveImage_NoExistingImage_NoError` - 엣지 케이스
4. `updateProfile_TTLRestore_WhenRemovingImage` - TTL 복원 확인

## 참고
- 게시글 이미지 처리 로직(`PostService.updatePost`) 패턴 참조
- TTL 복원으로 고아 이미지는 1시간 후 배치 자동 삭제
- API 일관성 확보: 게시글과 프로필 모두 동일한 제거 인터페이스 제공